### PR TITLE
changed longtitude column into longitude

### DIFF
--- a/db/migrate/20180806093113_change_longitude_column_name.rb
+++ b/db/migrate/20180806093113_change_longitude_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeLongitudeColumnName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :photos, :longtitude, :longitude 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_06_083831) do
+ActiveRecord::Schema.define(version: 2018_08_06_093113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2018_08_06_083831) do
     t.string "image_url"
     t.string "description"
     t.float "latitude"
-    t.float "longtitude"
+    t.float "longitude"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Changed Photos table column longtitude into longitude (spelling error)
table is now:

  create_table "photos", force: :cascade do |t|
    t.string "image_url"
    t.string "description"
    t.float "latitude"
    t.float "longitude"
    t.integer "user_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false

remember to bundle install, then rails db:migrate after downloading the new master file